### PR TITLE
Add dev as keyword to the composer schema to let composer ask if it d…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,9 @@
     "name": "backendtea/architect",
     "description": "Architectural checks for your codebase",
     "type": "library",
+    "keywords": [
+        "dev"
+    ],
     "require-dev": {
         "phpunit/phpunit": "^10.0||^11.0",
         "phpstan/phpstan": "^1.11",


### PR DESCRIPTION
Add dev as keyword to the composer schema to let composer ask if it does want it to install as dev.

See: https://getcomposer.org/doc/04-schema.md#keywords

> Note: Some special keywords trigger composer require without the --dev option to prompt users if they would like to add these packages to require-dev instead of require. These are: dev, testing, static analysis.